### PR TITLE
BUG: Generation of export header is unconditional

### DIFF
--- a/core/vul/CMakeLists.txt
+++ b/core/vul/CMakeLists.txt
@@ -65,12 +65,6 @@ else()
   vxl_add_library(LIBRARY_NAME ${VXL_LIB_PREFIX}vul LIBRARY_SOURCES ${vul_sources})
   vxl_add_library(LIBRARY_NAME ${VXL_LIB_PREFIX}vul_network LIBRARY_SOURCES ${vul_network_sources})
 endif()
-include(GenerateExportHeader)
-generate_export_header(${VXL_LIB_PREFIX}vul BASE_NAME vul)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/vul_export.h
-    DESTINATION ${VXL_INSTALL_INCLUDE_DIR}/core/vul
-    PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
-    COMPONENT Development )
 
 if(NOT UNIX)
   target_link_libraries( ${VXL_LIB_PREFIX}vul ws2_32 )
@@ -81,6 +75,13 @@ if(SOLARIS)
 endif()
 
 endif()
+
+include(GenerateExportHeader)
+generate_export_header(${VXL_LIB_PREFIX}vul BASE_NAME vul)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/vul_export.h
+    DESTINATION ${VXL_INSTALL_INCLUDE_DIR}/core/vul
+    PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
+    COMPONENT Development )
 
 target_link_libraries( ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vcl )
 


### PR DESCRIPTION
The generation of the vul_export.h file was in a conditional part
of the cmake list based on platform type.  It is now pushed outside of
the platform definition section.
