### PR TITLE
BUG: Define vnl_math::sqrteps as exactly-representable 0x1p-26

### DIFF
--- a/core/vnl/vnl_math.h
+++ b/core/vnl/vnl_math.h
@@ -123,7 +123,7 @@ inline constexpr double euler = 0.57721566490153286061;            // http://oei
 
 //: IEEE double machine precision
 inline constexpr double eps = std::numeric_limits<double>::epsilon();
-inline constexpr double sqrteps = 1.490116119384766e-08;
+inline constexpr double sqrteps = 0x1p-26; // sqrt(eps) = sqrt(2^-52) = 2^-26, exactly representable
 //: IEEE single machine precision
 inline constexpr float float_eps = std::numeric_limits<float>::epsilon();
 inline constexpr float float_sqrteps = 3.4526698300e-4f;


### PR DESCRIPTION
`vnl_math::sqrteps` was the literal `1.490116119384766e-08`, which is one ULP above the exact value of `sqrt(eps)`. Since `eps = 2^-52`, `sqrt(eps) = 2^-26` is a power of two and exactly representable, so this defines it as `0x1p-26`.

<details>
<summary>Numerical detail</summary>

- `eps = std::numeric_limits<double>::epsilon() = 2^-52`
- `sqrt(2^-52) = 2^-26 = 1.490116119384765625e-8` exactly (power of two → exactly representable)
- The old literal `1.490116119384766e-08` is `3.75e-24` above that exact value, exceeding the half-ULP threshold (~`1.65e-24`), so it rounds to `2^-26 + 2^-78` — one ULP high.
- `0x1p-26` is the unambiguous spelling of the intended value and equals what IEEE-754 `sqrt(eps)` returns at runtime (and what C++26 `constexpr std::sqrt(eps)` will yield).
- `vgl` already relies on the exact value: `core/vgl/vgl_triangle_3d.cxx` computes `sqrteps = std::sqrt(numeric_limits<double>::epsilon())` at runtime, which is exactly `0x1p-26`.

Verified locally: `vnl_math::sqrteps == 0x1p-26 == std::sqrt(std::numeric_limits<double>::epsilon())`; vnl test suite passes.

</details>

Reported via greptile review on InsightSoftwareConsortium/ITK#6427.

<!--
provenance: claude-code session 2026-06-10
source: https://github.com/InsightSoftwareConsortium/ITK/pull/6427#discussion_r3385019250
branch: hjmjohnson:fix-vnl-sqrteps-exact-2pow26 (single commit a4d172b746, based on origin/master cf2b6e0f6f)
base: InsightSoftwareConsortium/vxl:for/itk-vxl-master
file: core/vnl/vnl_math.h:126
-->
