### PR TITLE
COMP: Skip fpclassify for integral vnl_math classification predicates

### DIFF
--- a/core/vnl/vnl_math.h
+++ b/core/vnl/vnl_math.h
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <complex>
 #include <limits>
+#include <type_traits>
 #include <utility>
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
@@ -179,29 +180,45 @@ namespace numeric_predicates
 {
 // Wrap the <cmath> classification functions to guarantee a bool return type;
 // some standard libraries returned a signed integer from these.
+// Integral arguments are short-circuited: an integer is always finite, never
+// inf/NaN, and normal when non-zero. This also avoids an ambiguous fpclassify
+// overload in older Windows SDK <corecrt_math.h> integer templates, where
+// std::isfinite/isnan of an integer fails to compile (error C2668).
 template <typename TArg>
 inline bool
 isinf(TArg arg)
 {
-  return bool(std::isinf(arg));
+  if constexpr (std::is_integral_v<TArg>)
+    return false;
+  else
+    return bool(std::isinf(arg));
 }
 template <typename TArg>
 inline bool
 isnan(TArg arg)
 {
-  return bool(std::isnan(arg));
+  if constexpr (std::is_integral_v<TArg>)
+    return false;
+  else
+    return bool(std::isnan(arg));
 }
 template <typename TArg>
 inline bool
 isfinite(TArg arg)
 {
-  return bool(std::isfinite(arg));
+  if constexpr (std::is_integral_v<TArg>)
+    return true;
+  else
+    return bool(std::isfinite(arg));
 }
 template <typename TArg>
 inline bool
 isnormal(TArg arg)
 {
-  return bool(std::isnormal(arg));
+  if constexpr (std::is_integral_v<TArg>)
+    return arg != TArg(0);
+  else
+    return bool(std::isnormal(arg));
 }
 } // namespace numeric_predicates
 


### PR DESCRIPTION
Skip `fpclassify` for integral `vnl_math` classification predicates so integer-typed `vnl_matrix`/`vnl_vector` compile on MSVC toolsets where `fpclassify(<integral>)` is ambiguous.

<details>
<summary>Root cause</summary>

`numeric_predicates::isfinite/isnan/isinf/isnormal` forward `std::isfinite(arg)` (etc.) for every `TArg`. For integral `TArg` this instantiates the Windows UCRT `<corecrt_math.h>` integer template

```cpp
template <class _Ty> inline bool isfinite(_In_ _Ty _X) throw() { return fpclassify(_X) <= 0; }
```

where `fpclassify(<integral>)` is an ambiguous call (`error C2668`: `float`/`double`/`long double`) on e.g. MSVC 14.38.33130 (cl 19.38) + Windows SDK ≤ 10.0.22621. Every integer-typed `vnl_matrix`/`vnl_vector` TU fails to compile; newer toolsets (MSVC 14.44) are unaffected.

Fix: short-circuit integral arguments with `if constexpr` — an integer is always finite, never inf/NaN, normal when non-zero — avoiding the ambiguous SDK template.

</details>

<details>
<summary>Validation</summary>

The equivalent change applied to ITK's vendored copy of this file builds all of ITK (**3396/3396 targets, 0 errors**) on the failing toolchain (MSVC 14.38.33130, Windows SDK 10.0.22621.0). Carried as ITK PR InsightSoftwareConsortium/ITK#6451 pending this upstream fix.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code (claude-opus-4-8)
- Role: diagnosed the ambiguous SDK `fpclassify` integer template, authored the `if constexpr` guard, validated via a full ITK build.

</details>
